### PR TITLE
Health Check Endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,19 +5,28 @@ import process from 'process'
 dotenv.config()
 const app = express()
 
-// get the port from env variable
 const PORT = process.env.PORT || 5000
 
+app.use((req, res, next) => {
+  next()
+})
+
 app.use(express.static('dist'))
+app.use(express.json())
 
 app.get('/version', (req, res) => {
-  res.send('New version is deployed') // change this string to ensure a new version deployed
+  res.send('New version is deployed')
 })
 
 app.get('/health', (req, res) => {
-  // eslint-disable-next-line no-constant-condition
-  if (true) throw('error...  ')
   res.send('ok')
+})
+
+app.use((err, req, res, next) => {
+  // eslint-disable-next-line no-console
+  console.error(err.stack)
+  res.status(500).send('Something broke!')
+  next(err)
 })
 
 app.listen(PORT, () => {

--- a/app.js
+++ b/app.js
@@ -14,6 +14,12 @@ app.get('/version', (req, res) => {
   res.send('New version is deployed') // change this string to ensure a new version deployed
 })
 
+app.get('/health', (req, res) => {
+  // eslint-disable-next-line no-constant-condition
+  if (true) throw('error...  ')
+  res.send('ok')
+})
+
 app.listen(PORT, () => {
   // eslint-disable-next-line no-console
   console.log(`server started on port ${PORT}`)


### PR DESCRIPTION
The /health endpoint is designed to provide a health check for the application. It is a GET request handler that currently throws an error unconditionally, simulating a failure scenario. This endpoint can be used to monitor the application's health status and ensure it is running correctly. The current implementation is likely for testing purposes and should be updated to reflect actual health check logic.